### PR TITLE
Fix ArgoCD plugin command args

### DIFF
--- a/examples/gitops/install/kcl-cmp.yaml
+++ b/examples/gitops/install/kcl-cmp.yaml
@@ -15,5 +15,4 @@ data:
         command: ["sh"]
         args:
           - -c
-          - kcl
-          - run
+          - kcl run


### PR DESCRIPTION
The shell command needs to be a single string to work properly