### PR TITLE
Update kcl-cmp.yaml fix #386

### DIFF
--- a/examples/gitops/install/kcl-cmp.yaml
+++ b/examples/gitops/install/kcl-cmp.yaml
@@ -21,7 +21,7 @@ data:
             export KCL_CACHE_PATH=$(mktemp -d /tmp/kcl_cache.XXXXXXXXXX)
             export KCL_PKG_PATH=$(mktemp -d /tmp/kcl_pkg.XXXXXXXXXX)
             tempfile=$(mktemp)
-            kcl run -q -o $tempfile
+            kcl run -q -o $tempfile > /dev/null 2>&1
             error=$?
             if [ $error -eq 0 ]; then
               cat $tempfile


### PR DESCRIPTION
if the target project is using the k8s module kcl will print: 
```bash
downloading 'kcl-lang/k8s:1.29' from 'ghcr.io/kcl-lang/k8s:1.29' 
```
to stdout making argcocd fail

<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [X] Y 

fix #386

#### 2. What is the scope of this PR (e.g. component or file name):

fix example integration

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [X] Other

Force kcl to not print to stdout for the argo integration

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [X] N
- [ ] Y 

