### PR TITLE
Configure CNCF GA4 website measurement ID

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -308,7 +308,7 @@ const config = {
     [
       '@docusaurus/plugin-google-gtag',
       {
-        trackingID: 'G-MZD1X1PB2Q',
+        trackingID: ['G-4D8SMCEJK8', 'G-MZD1X1PB2Q'],
         anonymizeIP: true,
       },
     ],


### PR DESCRIPTION
- Fixes #502
- Adds the CNCF-owned GA4 ID to the website config
- If you prefer adding Admin access to your existing measurement ID, let me know.

Related:

- #505