### PR TITLE
Fix typos having the sign on the wrong side of the "e" for floating point numbers in scientific notation

### DIFF
--- a/docs/reference/lang/spec/datatypes.md
+++ b/docs/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/reference/lang/spec/datatypes.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.10/reference/lang/spec/datatypes.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.10/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.11/reference/lang/spec/datatypes.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.11/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.12/reference/lang/spec/datatypes.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.12/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.4/reference/lang/spec/datatypes.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.4/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.5/reference/lang/spec/datatypes.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.5/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.6/reference/lang/spec/datatypes.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.6/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.7/reference/lang/spec/datatypes.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.7/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.8/reference/lang/spec/datatypes.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.8/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.9/reference/lang/spec/datatypes.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.9/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 

--- a/versioned_docs/version-0.11/reference/lang/spec/datatypes.md
+++ b/versioned_docs/version-0.11/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 

--- a/versioned_docs/version-0.12/reference/lang/spec/datatypes.md
+++ b/versioned_docs/version-0.12/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 

--- a/versioned_docs/version-0.4/reference/lang/spec/datatypes.md
+++ b/versioned_docs/version-0.4/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 

--- a/versioned_docs/version-0.5/reference/lang/spec/datatypes.md
+++ b/versioned_docs/version-0.5/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 

--- a/versioned_docs/version-0.6/reference/lang/spec/datatypes.md
+++ b/versioned_docs/version-0.6/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 

--- a/versioned_docs/version-0.7/reference/lang/spec/datatypes.md
+++ b/versioned_docs/version-0.7/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 

--- a/versioned_docs/version-0.8/reference/lang/spec/datatypes.md
+++ b/versioned_docs/version-0.8/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 

--- a/versioned_docs/version-0.9/reference/lang/spec/datatypes.md
+++ b/versioned_docs/version-0.9/reference/lang/spec/datatypes.md
@@ -45,10 +45,10 @@ Float, floating-point, approximation to real numbers, positive or negative, cont
 a = 1.10
 b = 1.0
 c = -35.59
-d = 32.3+e18
+d = 32.3e+18
 f = -90.
 g = -32.54e100
-h = 70.2-E12
+h = 70.2E-12
 i = float("112")  # float constructor
 ```
 


### PR DESCRIPTION
This fixed a small typo.

According to the formal grammar floats have the form:

```
FLOAT_NUMBER: /(([-+]?\d+\.\d*|\.\d+)(e[-+]?\d+)?|\d+(e[-+]?\d+))/i
```

Where the sign follows the `e`. This is consistent with scientific notation. Examples had the sign preceding the `e`.
