### PR TITLE
feat(lambda): arguments can be passed on multiple lines

### DIFF
--- a/docs/reference/lang/spec/kcl-spec.md
+++ b/docs/reference/lang/spec/kcl-spec.md
@@ -208,7 +208,9 @@ config_entries: config_entry ((COMMA [NEWLINE] | [NEWLINE]) config_entry)* [COMM
 config_entry: test (COLON | ASSIGN | COMP_PLUS) test | double_star_expr | if_entry
 
 //////////// lambda_expr ////////////
-lambda_expr: LAMBDA [schema_arguments] [RIGHT_ARROW type] LEFT_BRACE [expr_stmt | NEWLINE _INDENT schema_init_stmt+ _DEDENT] RIGHT_BRACE
+lambda_expr: LAMBDA [lambda_signature] LEFT_BRACE [expr_stmt | NEWLINE _INDENT schema_init_stmt+ _DEDENT] RIGHT_BRACE
+lambda_signature: (schema_arguments [RIGHT_ARROW type] | multiline_lambda_signature)
+multiline_lambda_signature: LEFT_BRACE NEWLINE* schema_argument (COMMA NEWLINE* schema_argument)* NEWLINE* RIGHT_BRACE RIGHT_ARROW type
 
 //////////// misc ////////////
 number: DEC_NUMBER [multiplier] | HEX_NUMBER | BIN_NUMBER | OCT_NUMBER | FLOAT_NUMBER

--- a/docs/reference/lang/tour.md
+++ b/docs/reference/lang/tour.md
@@ -1341,6 +1341,7 @@ a = func(1, 1)  # 2
 
 - The value of the last expression is used as the return value of the function, and the empty function body returns `None`.
 - The return value type annotation can be omitted, and the return value type is the type of the last expression value.
+- Arguments can be passed on multiple lines if put in between braces, in such a case the return type is required.
 - There is no order-independent feature in the function body, all expressions are executed in order.
 
 ```kcl
@@ -1353,6 +1354,18 @@ _func = lambda x: int, y: int -> int {
 _func = lambda x: int, y: int -> str {
     str(x + y)
 }  # Error (int, int) -> str can't be assigned to (int, int) -> int
+_func = lambda {
+    x: int,
+    y: int
+} -> int {
+    x - y
+}  # Ok
+_func = lambda {
+    x: int,
+    y: int
+} {  # The following block will not be interpreted as part of the lambda
+    x - y
+}  # Error expected one of ["="] got ,
 ```
 
 The function type variables cannot participate in any calculations and can only be used in assignment statements and call statements.


### PR DESCRIPTION


#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

Relates-to: kcl-lang/kcl#2082
Relates-to: kcl-lang/kcl#1941


<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

KCL syntax.

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

Updates the syntax definition and adds information on the fact that lambda arguments can now be passed on multiple lines.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

No.