### PR TITLE
ci: bump actions/setup-go to v7 as v1 is deprecated

### DIFF
--- a/.github/workflows/example-e2e-test.yml
+++ b/.github/workflows/example-e2e-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.22"
 

--- a/.github/workflows/example-e2e-test.yml
+++ b/.github/workflows/example-e2e-test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.22"
+          go-version: "1.26"
 
       - name: kcl Installation
         run: go install kcl-lang.io/cli/cmd/kcl@main

--- a/.github/workflows/install-kcl.yml
+++ b/.github/workflows/install-kcl.yml
@@ -17,7 +17,7 @@ jobs:
         shell: bash -leo pipefail {0}
         run: sudo kcl version && sudo kcl run ./examples/configuration/nginx.k
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.22"
 
@@ -42,7 +42,7 @@ jobs:
           kcl version
           kcl run ./examples/configuration/nginx.k
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.22"
 
@@ -64,7 +64,7 @@ jobs:
         run: C:\kclvm\bin\kcl.exe run ./examples/configuration/nginx.k
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v7
         with:
           go-version: "1.22"
 

--- a/.github/workflows/install-kcl.yml
+++ b/.github/workflows/install-kcl.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.22"
+          go-version: "1.26"
 
       - name: Check Go Installation
         run: go install kcl-lang.io/cli/cmd/kcl@main && sudo $HOME/go/bin/kcl version && sudo $HOME/go/bin/kcl run ./examples/configuration/nginx.k
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.22"
+          go-version: "1.26"
 
       - name: Check Go Installation
         run: go install kcl-lang.io/cli/cmd/kcl@main && sudo $HOME/go/bin/kcl version && sudo $HOME/go/bin/kcl run ./examples/configuration/nginx.k
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.22"
+          go-version: "1.26"
 
       - name: Check Go Installation
         run: go install kcl-lang.io/cli/cmd/kcl@main && C:\Users\runneradmin\go\bin\kcl.exe run ./examples/configuration/nginx.k


### PR DESCRIPTION
E2E workflow currently fails due to v1 requiring Node 20 which is deprecated on the GH runners.