### PR TITLE
docs(konfig): add `kcl mod update` step to quick-start

### DIFF
--- a/docs/user_docs/guides/working-with-konfig/3-quick-start.md
+++ b/docs/user_docs/guides/working-with-konfig/3-quick-start.md
@@ -38,10 +38,12 @@ git clone https://github.com/kcl-lang/konfig.git && cd konfig
 
 The programming language of the project is KCL, not JSON/YAML which Kubernetes recognizes, so it needs to be compiled to get the final output.
 
-Enter stack dir `examples/appops/nginx-example/dev` and compile:
+Enter stack dir `examples/appops/nginx-example/dev`, resolve the dependencies first (the example uses a relative `path` dependency in `kcl.mod` that may not resolve on every checkout — running `kcl mod update` will refresh `kcl.mod.lock` against the published OCI artifact), and compile:
 
 ```bash
-cd examples/appops/nginx-example/dev && kcl run -D appenv=dev
+cd examples/appops/nginx-example/dev
+kcl mod update
+kcl run -D appenv=dev
 ```
 
 The output YAML is:

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/user_docs/guides/working-with-konfig/3-quick-start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/user_docs/guides/working-with-konfig/3-quick-start.md
@@ -38,10 +38,12 @@ git clone https://github.com/kcl-lang/konfig.git && cd konfig
 
 Konfig 的编程语言是 KCL，不是 Kubernetes 认识的 JSON/YAML，因此还需要编译得到最终输出。
 
-进入到项目的 Stack 目录（`examples/appops/nginx-example/dev`）并执行编译：
+进入到项目的 Stack 目录（`examples/appops/nginx-example/dev`），先刷新依赖（示例中 `kcl.mod` 使用了相对 `path` 依赖，部分环境下可能无法正确解析；运行 `kcl mod update` 会基于发布的 OCI 制品刷新 `kcl.mod.lock`），然后执行编译：
 
 ```bash
-cd examples/appops/nginx-example/dev && kcl run
+cd examples/appops/nginx-example/dev
+kcl mod update
+kcl run -D appenv=dev
 ```
 
 可以获得如下 YAML 输出:


### PR DESCRIPTION
## Summary

- Add a `kcl mod update` step before `kcl run` in the Konfig quick-start guide (EN + zh-CN).
- Resolves the class of issue reported in kcl-lang/kcl-lang discussion #2126, where users hit `invalid value 'UndefinedType' to load attribute 'replicas'` after a fresh clone.

## Background

The examples in [`kcl-lang/konfig`](https://github.com/kcl-lang/konfig) declare `konfig` as a relative `path` dependency in `kcl.mod`:

\`\`\`toml
konfig = { path = "../../../../../konfig" }
\`\`\`

Even when the path resolves, `kcl run` rewrites `kcl.mod.lock` against the published OCI artifact. On systems where the path does not resolve correctly (e.g. when the checkout directory structure differs, or with stale lock files), users can hit runtime evaluation errors such as:

\`\`\`
EvaluationError
--> .../konfig/models/kube/backend/server_backend.k:67:1
|
67 | replicas = config.replicas
| invalid value 'UndefinedType' to load attribute 'replicas'
\`\`\`

Running `kcl mod update` first ensures the dependency is resolved against the published OCI artifact (`konfig:0.14.0`) before `kcl run`, so the relative `path` is bypassed.

## Test plan

- [x] Verified \`kcl mod update && kcl run -D appenv=dev\` works on a fresh clone of \`kcl-lang/konfig\` with KCL \`0.12.x\`.
- [x] Verified the change renders correctly in the EN and zh-CN \`current\` docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)